### PR TITLE
chore (ci): refactor to use non-deprecated images, add matrix for 2.9 and 2.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Tests
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       CKAN_REDIS_URL: redis://redis:6379/1
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install requirements
       # Install any extra requirements your extension has here (dev requirements, other extensions etc)
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       image: openknowledge/ckan-dev:2.9
     services:
       solr:
-        image: ckan/ckan-solr-dev:2.9
+        image: ckan/ckan-solr:2.9-solr9
       postgres:
         image: ckan/ckan-postgres-dev:2.9
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,22 +1,33 @@
 name: Tests
-on: [push, pull_request, workflow_dispatch]
+on: 
+  push:
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   test:
+    strategy:
+      matrix:
+        include: #ckan-image see https://github.com/ckan/ckan-docker-base, ckan-version controls other image tags
+          - ckan-version: "2.9"
+            ckan-image: "2.9-py3.9"
+            experimental: false
+
     runs-on: ubuntu-latest
     container:
-      # The CKAN version tag of the Solr and Postgres containers should match
-      # the one of the container the tests run on.
-      # You can switch this base image with a custom image tailored to your project
-      image: openknowledge/ckan-dev:2.9
+      image: ckan/ckan-dev:${{ matrix.ckan-image }}
+      options: --user root
     services:
       solr:
-        image: ckan/ckan-solr:2.9-solr9
+        image: ckan/ckan-solr:${{ matrix.ckan-version }}-solr9
       postgres:
-        image: ckan/ckan-postgres-dev:2.9
+        image: ckan/ckan-postgres-dev:${{ matrix.ckan-version }}
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       redis:
           image: redis:3
@@ -30,19 +41,29 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      continue-on-error: ${{ matrix.experimental }}
+
+    - name: Pin setuptools for ckan 2.9 only
+      if: ${{ matrix.ckan-version == 2.9 }}
+      run: pip install "setuptools>=44.1.0,<71"
+      continue-on-error: ${{ matrix.experimental }}
+
     - name: Install requirements
       # Install any extra requirements your extension has here (dev requirements, other extensions etc)
       run: |
         pip install -r requirements.txt
         pip install -r dev-requirements.txt
         pip install -e .
-    - name: Setup extension
-      # Extra initialization steps
-      run: |
+        pip install -U requests[security]
         # Replace default path to CKAN core config file with the one on the container
         sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
 
+    - name: Setup extension
+      continue-on-error: ${{ matrix.experimental }}
+      run: |
         ckan -c test.ini db init
+
     - name: Run tests
-      run: pytest --ckan-ini=test.ini --cov=ckanext.multiuploader --disable-warnings ckanext/multiuploader
+      continue-on-error: ${{ matrix.experimental }}
+      run: pytest --ckan-ini=test.ini --cov=ckanext.multiuploader --disable-warnings ckanext/multiuploader --junit-xml=/tmp/artifacts/junit/results.xml
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,11 +62,16 @@ jobs:
         # Replace default path to CKAN core config file with the one on the container
         sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
 
+
+    - name: Install curl
+      run: apt-get update && apt-get install -y curl
+
     - name: Check Solr schema version
       run: curl -s "http://solr:8983/solr/ckan/admin/file?file=schema.xml"
 
     - name: Fetch Solr logs
       run: docker logs $(docker ps -qf "ancestor=ckan/ckan-solr:${{ matrix.ckan-version }}-solr9") || true
+
 
     - name: Setup extension
       continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,11 @@ jobs:
         # Replace default path to CKAN core config file with the one on the container
         sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
 
+    - name: Setup extension
+      continue-on-error: ${{ matrix.experimental }}
+      run: |
+        ckan -c test.ini db init
+
 
     - name: Install curl
       run: apt-get update && apt-get install -y curl
@@ -73,10 +78,6 @@ jobs:
       run: docker logs $(docker ps -qf "ancestor=ckan/ckan-solr:${{ matrix.ckan-version }}-solr9") || true
 
 
-    - name: Setup extension
-      continue-on-error: ${{ matrix.experimental }}
-      run: |
-        ckan -c test.ini db init
 
     - name: Run tests
       continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,10 +64,8 @@ jobs:
 
     - name: Setup extension
       continue-on-error: ${{ matrix.experimental }}
-#      run: |
-#        ckan -c test.ini db init
       run: |
-        ckan db init
+        ckan -c test.ini db init
 
 
     - name: Install curl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,19 +11,21 @@ jobs:
         include: #ckan-image see https://github.com/ckan/ckan-docker-base, ckan-version controls other image tags
           - ckan-version: "2.9"
             ckan-image: "2.9-py3.9"
+            solr-image: "2.9-solr8"
             experimental: false
           - ckan-version: "2.10"
             ckan-image: "2.10-py3.10"
+            solr-image: "2.10-solr8"
             experimental: false
       fail-fast: false
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ckan/ckan-dev:${{ matrix.ckan-image }}
       options: --user root
     services:
       solr:
-        image: ckan/ckan-solr:${{ matrix.ckan-version }}-solr8
+        image: ckan/ckan-solr:${{ matrix.solr-image }}
       postgres:
         image: ckan/ckan-postgres-dev:${{ matrix.ckan-version }}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,12 @@ jobs:
         # Replace default path to CKAN core config file with the one on the container
         sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
 
+    - name: Check Solr schema version
+      run: curl -s "http://solr:8983/solr/ckan/admin/file?file=schema.xml"
+
+    - name: Fetch Solr logs
+      run: docker logs $(docker ps -qf "ancestor=ckan/ckan-solr:${{ matrix.ckan-version }}-solr9") || true
+
     - name: Setup extension
       continue-on-error: ${{ matrix.experimental }}
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ jobs:
           - ckan-version: "2.9"
             ckan-image: "2.9-py3.9"
             experimental: false
+          - ckan-version: "2.10"
+            ckan-image: "2.10-py3.10"
+            experimental: false
+      fail-fast: false
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       options: --user root
     services:
       solr:
-        image: ckan/ckan-solr:${{ matrix.ckan-version }}-solr9
+        image: ckan/ckan-solr:${{ matrix.ckan-version }}-solr8
       postgres:
         image: ckan/ckan-postgres-dev:${{ matrix.ckan-version }}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,8 +71,13 @@ jobs:
     - name: Install curl
       run: apt-get update && apt-get install -y curl
 
-    - name: Check Solr schema version
-      run: curl -s "http://solr:8983/solr/ckan/admin/file?file=schema.xml"
+    - name: Check Solr
+      run: |
+        echo "Checking Solr core status..."
+        curl -f http://solr:8983/solr/admin/cores?action=STATUS || echo "Solr core status failed"
+        echo "Checking schema.xml..."
+        curl -f -s "http://solr:8983/solr/ckan/admin/file?file=schema.xml" || echo "schema.xml not found"
+
 
     - name: Fetch Solr logs
       run: docker logs $(docker ps -qf "ancestor=ckan/ckan-solr:${{ matrix.ckan-version }}-solr9") || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,8 +64,10 @@ jobs:
 
     - name: Setup extension
       continue-on-error: ${{ matrix.experimental }}
+#      run: |
+#        ckan -c test.ini db init
       run: |
-        ckan -c test.ini db init
+        ckan db init
 
 
     - name: Install curl

--- a/test.ini
+++ b/test.ini
@@ -10,7 +10,7 @@ port = 5000
 
 [app:main]
 use = config:../ckan/test-core.ini
-#ckan.plugins = multiuploader
+ckan.plugins = multiuploader
 #solr_url = http://127.0.0.1:8983/solr/ckan
 
 

--- a/test.ini
+++ b/test.ini
@@ -10,7 +10,7 @@ port = 5000
 
 [app:main]
 use = config:../ckan/test-core.ini
-ckan.plugins = multiuploader
+#ckan.plugins = multiuploader
 #solr_url = http://127.0.0.1:8983/solr/ckan
 
 

--- a/test.ini
+++ b/test.ini
@@ -11,7 +11,7 @@ port = 5000
 [app:main]
 use = config:../ckan/test-core.ini
 ckan.plugins = multiuploader
-solr_url = http://127.0.0.1:8983/solr/ckan
+#solr_url = http://127.0.0.1:8983/solr/ckan
 
 
 # Logging configuration

--- a/test.ini
+++ b/test.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-debug = true
+debug = false
 smtp_server = localhost
 error_email_from = ckan@localhost
 
@@ -10,8 +10,8 @@ port = 5000
 
 [app:main]
 use = config:../ckan/test-core.ini
-ckan.plugins = multiuploader
-#solr_url = http://127.0.0.1:8983/solr/ckan
+ckan.plugins = multiuploader datastore
+solr_url = http://127.0.0.1:8983/solr/ckan
 
 
 # Logging configuration


### PR DESCRIPTION
2.10 fails with issues reported in #1 